### PR TITLE
add ScrollWithOverflow component

### DIFF
--- a/src/components/ScrollWithOverflow/index.js
+++ b/src/components/ScrollWithOverflow/index.js
@@ -1,0 +1,78 @@
+import React, { PureComponent } from 'react'
+import styled from 'styled-components'
+import PropTypes from 'prop-types'
+
+/**
+ * ScrollWithOverflow is a component intended to allow scrolling in the
+ * y-direction and overflow in the x-direction.
+ *
+ * Naively, this would just be achieved by setting
+ *    overflow-x: visible;
+ *    overflow-y: scroll;
+ * on whatever div you want. But that doesn't work:
+ *    https://stackoverflow.com/questions/6421966/css-overflow-x-visible-and-overflow-y-hidden-causing-scrollbar-issue
+ * This component solves the problem by adding positive padding and
+ * negative margin:
+ *  padding-right: 100vw;
+ *  margin-right: -100vw;
+ * so that children can appear to overflow without actually overflowing.
+ *
+ * This approach has a few downsides:
+ *  1. Other elements in the padding region do not receive pointer events.
+ *    - solved by conditional application of pointer-events:none
+ *  2. The scrollbar disappears (pushed by padding)
+ *    - TODO: Solve this, or at least alleviate with other styling (like
+ *      top/bottom shadows) to indicate scrolling
+ * Not ideal, but the best I've got for now...
+ */
+
+const ScrollingDiv = styled.div`
+  overflow-y: scroll;
+  padding-right: 100vw;
+  margin-right: -100vw;
+  height: calc(100% - 50px);
+  pointer-events: ${props => props.disablePointer ? 'none' : 'auto'};
+`
+
+const ScrollingDivInner = styled.div`
+  overflow-x:visible;
+  pointer-events:auto;
+  height:100%;
+`
+
+export default class ScrollWithOverflow extends PureComponent {
+
+  static propTypes = {
+    children: PropTypes.oneOfType( [
+      PropTypes.arrayOf(PropTypes.node),
+      PropTypes.node
+    ] )
+  }
+
+  state = {
+    isHovering: false
+  }
+
+  onMouseEnter = () => {
+    this.setState( { isHovering: true } )
+  }
+  onMouseLeave = () => {
+    this.setState( { isHovering: false } )
+  }
+
+  render() {
+    return (
+      <ScrollingDiv
+        disablePointer={!this.state.isHovering}
+      >
+        <ScrollingDivInner
+          onMouseEnter={this.onMouseEnter}
+          onMouseLeave={this.onMouseLeave}
+        >
+          {this.props.children}
+        </ScrollingDivInner>
+      </ScrollingDiv>
+    )
+  }
+
+}

--- a/src/views/Math3dController.js
+++ b/src/views/Math3dController.js
@@ -1,24 +1,16 @@
 import React from 'react'
 import Drawer from '../containers/Drawer'
 import SortableTree from 'containers/SortableTree'
-import styled from 'styled-components'
 import ControllerHeader from 'containers/ControllerHeader'
-
-const ScrollingDiv = styled.div`
-  overflow-y: scroll;
-  overflow-x: hidden;
-  padding-right: 500px;
-  margin-right: -500px;
-  height: calc(100% - 50px);
-`
+import ScrollWithOverflow from 'components/ScrollWithOverflow'
 
 const Math3dController = () => {
   return (
     <Drawer id='main' width='400px'>
       <ControllerHeader/>
-      <ScrollingDiv>
+      <ScrollWithOverflow>
         <SortableTree />
-      </ScrollingDiv>
+      </ScrollWithOverflow>
     </Drawer>
   )
 }


### PR DESCRIPTION
Implements @stardust66's idea from #13, but solves the pointer-event issue.

I'm still not 100% happy with this approaching to allowing scroll-y and overflow-x. I wish the scrollbar would appear in the correct position. But we'll live with it for now.