### PR TITLE
Slider bugs

### DIFF
--- a/react-ui/src/containers/MathObjects/MathSymbols/VariableSlider/components/AnimationControls.js
+++ b/react-ui/src/containers/MathObjects/MathSymbols/VariableSlider/components/AnimationControls.js
@@ -3,6 +3,8 @@ import React, { PureComponent } from 'react'
 import { Button, Icon } from 'antd'
 import styled from 'styled-components'
 
+window.timers = {}
+
 const AnimationControlsContainer = styled.div`
   display: flex;
   flex: 1;
@@ -89,12 +91,13 @@ export default class AnimationControls extends PureComponent<Props> {
     this.props.setProperty('isAnimating', true)
     const { baseAnimationDuration, fps, speedMultiplier } = this.props
     const duration = baseAnimationDuration/speedMultiplier
-    const delay = 1/fps
+    const delay = 1/fps // delay in SECONDS !
+    const delayMs = delay * 1000 // delay in ms
     const fractionalStepSize = delay/duration // inverse of numSteps = duration/delay
     const incrementByFraction = this.props.incrementByFraction
     this._interval = setInterval(
       () => incrementByFraction(fractionalStepSize),
-      delay
+      delayMs
     )
   }
 

--- a/react-ui/src/containers/MathObjects/MathSymbols/VariableSlider/components/VariableSlider.js
+++ b/react-ui/src/containers/MathObjects/MathSymbols/VariableSlider/components/VariableSlider.js
@@ -71,10 +71,11 @@ export default class VariableSlider extends PureComponent<Props> {
     this.forceUpdate()
   }
 
-  static getLaTeX(manualValue: ?string, value: number) {
-    return (manualValue !== null && manualValue !== undefined)
-      ? manualValue
-      : value.toFixed(2)
+  static getLaTeX(manualValue: ?string, value: number, numDigits: ?number) {
+    if (manualValue !== null && manualValue !== undefined) {
+      return manualValue
+    }
+    return numDigits ? value.toFixed(numDigits) : value.toString()
   }
 
   render() {
@@ -83,7 +84,7 @@ export default class VariableSlider extends PureComponent<Props> {
       value,
       manualValue
     } = this.props
-    const valueText = VariableSlider.getLaTeX(manualValue, value)
+    const valueText = VariableSlider.getLaTeX(manualValue, value, 2)
     return (
       <MathObjectUI
         id={id}


### PR DESCRIPTION
This fixes two issues:
- production-version slider was running faster than development version. This was because I set the delay in seconds instead of milliseconds
- fixed a bug where timers would get stuck in increment was less than 0.01; this was a rounding issue.