### PR TITLE
change parametric curve function name prefix

### DIFF
--- a/react-ui/src/containers/MathObjects/MathGraphics/ParametricCurve/index.js
+++ b/react-ui/src/containers/MathObjects/MathGraphics/ParametricCurve/index.js
@@ -34,7 +34,7 @@ export class ParemetricCurveUI extends PureComponent<Props> {
         <MainRow>
           <MathInputRHS
             field='expr'
-            prefix='f(t)='
+            prefix='_f(t)='
             parentId={this.props.id}
           />
         </MainRow>

--- a/react-ui/src/containers/MathObjects/MathGraphics/metadata.js
+++ b/react-ui/src/containers/MathObjects/MathGraphics/metadata.js
@@ -216,7 +216,7 @@ export const vectorMeta: MetaData = {
 const parametricCurveSpecific: MetaData = {
   expr: {
     inputType: 'math',
-    defaultValue: 'f(t)=\\left[\\cos\\left(t\\right),\\ \\sin\\left(t\\right),\\ t\\right]',
+    defaultValue: '_f(t)=\\left[\\cos\\left(t\\right),\\ \\sin\\left(t\\right),\\ t\\right]',
     isPrimary: true
   },
   range: {

--- a/react-ui/src/store/mockState.js
+++ b/react-ui/src/store/mockState.js
@@ -153,7 +153,7 @@ const settingsList = [
   {
     type: PARAMETRIC_CURVE,
     folder: 'mainFolder',
-    expr: 'f(t)=\\left[\\cos(t),\\sin(t),T\\right]'
+    expr: '_f(t)=\\left[\\cos(t),\\sin(t),T\\right]'
   },
   ...varsList,
   randomLine(), randomLine(),


### PR DESCRIPTION
using `f(t)=` as the prefix caused circular assignment error if the right-hand-side was a user-defined function `f(t)`.

Using `_f(t)=` as the prefix is safe because users cannot define function names starting with an underscore. (MathQuill tries to make it a subscript.)