### PR TITLE
memoize the result of _getEval

### DIFF
--- a/react-ui/src/utils/mathParsing/MathExpression.js
+++ b/react-ui/src/utils/mathParsing/MathExpression.js
@@ -1,6 +1,7 @@
 // @flow
 import math from 'utils/mathjs'
 import type { Node } from 'utils/mathjs/types'
+import memoizeOne from 'memoize-one'
 
 export type PostProcessor = (Node) => void
 export type PreProcessor = (expression: string) => string
@@ -37,7 +38,7 @@ export default class MathExpression {
     this.name = this.tree.name ? this.tree.name : null
     this._postprocess(postprocessors)
 
-    this.eval = this._getEval()
+    this.eval = memoizeOne(this._getEval())
     this.dependencies = this._getDependencies()
   }
 


### PR DESCRIPTION
This applies `memoizeOne` to the result of `MathExpression._getEval().

This will still result in a bunch of unnecessary re-evaluations:

```
scope1 = { n: 2, a: 3 }
scope2 = { n: 2, a: 3 }
expr = parser.parse('f(t)=t^n')
expr.eval(scope1) === expr.eval(scope1) // true, good!

expr.eval(scope1) === expr.eval(scope2) /// false, bad!
```

Here, there was no need to re-calculate the result since the value of `n` did not change.

If I recall correctly, `memoizeOne` will let us specify a custom equality function to help avoid unncessary re-evaluations.