### PR TITLE
reset activeObject to null when rehydrating

### DIFF
--- a/react-ui/src/store/hydration.js
+++ b/react-ui/src/store/hydration.js
@@ -124,6 +124,7 @@ export function rehydrate(dehydrated) {
   const sortableTree = { ...sortableTreeFixedPortion, ...sortableTreeWithoutFixed }
 
   const rehydrated = {
+    activeObject: null,
     metadata: { ...metadataInitial, ...metadata },
     sortableTree,
     sliderValues,


### PR DESCRIPTION
Not reseting `activeObject` was causing a bug in some cases when loading graphs. If `activeObject="1"` and the new graph did not have an object with id `"1"`, then page would crash.