### PR TITLE
Fix folder ids

### DIFF
--- a/dotenv_template
+++ b/dotenv_template
@@ -1,5 +1,4 @@
-# Rename to .env
-# change REMOTE_MONGODB_URI
+# Rename to .env and change MONGODB_URI
 LOCAL_MONGODB_URI=mongodb://127.0.0.1:27017
 # something like...
-# REMOTE_MONGODB_URI=mongodb://<dbuser>:<dbpassword>@ds121753.mlab.com:21753/heroku_4h8rcbtf
+# MONGODB_URI=mongodb://<dbuser>:<dbpassword>@ds121753.mlab.com:21753/heroku_4h8rcbtf

--- a/react-ui/src/store/hydration.js
+++ b/react-ui/src/store/hydration.js
@@ -154,6 +154,10 @@ export function rehydrate(dehydrated) {
 function getMaxId(sortableTree) {
   let maxId = 0
   sortableTree.root.forEach(folderId => {
+    const folderIdasNumber = parseInt(folderId, 10)
+    if (folderIdasNumber > maxId) {
+      maxId = folderIdasNumber
+    }
     sortableTree[folderId].forEach(id => {
       const asNumber = parseInt(id, 10)
       if (asNumber > maxId) {


### PR DESCRIPTION
Resolves #196 

`getMaxId` was not including folders; bug only revealed its head when a folder was the max id, which is a pretty rare scenario (folder most recently created object that was not deleted).