### PR TITLE
Bugfixes

### DIFF
--- a/client/package-lock.json
+++ b/client/package-lock.json
@@ -7559,9 +7559,9 @@
       "integrity": "sha1-ksnBN0w1CF912zWexWzCV8u5P6Q="
     },
     "http-proxy": {
-      "version": "1.18.0",
-      "resolved": "https://registry.npmjs.org/http-proxy/-/http-proxy-1.18.0.tgz",
-      "integrity": "sha512-84I2iJM/n1d4Hdgc6y2+qY5mDaz2PUVjlg9znE9byl+q0uC3DeByqBGReQu5tpLK0TAqTIXScRUV+dg7+bUPpQ==",
+      "version": "1.18.1",
+      "resolved": "https://registry.npmjs.org/http-proxy/-/http-proxy-1.18.1.tgz",
+      "integrity": "sha512-7mz/721AbnJwIVbnaSv1Cz3Am0ZLT/UBwkC92VlxhXv/k/BBQfM2fXElQNC27BVGr0uwUpplYPQM9LnaBMR5NQ==",
       "requires": {
         "eventemitter3": "^4.0.0",
         "follow-redirects": "^1.0.0",
@@ -9504,9 +9504,9 @@
       }
     },
     "jquery": {
-      "version": "3.4.1",
-      "resolved": "https://registry.npmjs.org/jquery/-/jquery-3.4.1.tgz",
-      "integrity": "sha512-36+AdBzCL+y6qjw5Tx7HgzeGCzC81MDDgaUP8ld2zhx58HdqXGoBd+tHdrBMiyjGQs0Hxs/MLZTu/eHNJJuWPw==",
+      "version": "3.5.1",
+      "resolved": "https://registry.npmjs.org/jquery/-/jquery-3.5.1.tgz",
+      "integrity": "sha512-XwIBPqcMn57FxfT+Go5pzySnm4KWkT1Tv7gjrpT1srtf8Weynl6R273VJ5GjkRb51IzMp5nbaPjJXMWeju2MKg==",
       "dev": true
     },
     "js-tokens": {
@@ -9831,9 +9831,9 @@
       }
     },
     "lodash": {
-      "version": "4.17.15",
-      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.15.tgz",
-      "integrity": "sha512-8xOcRHvCjnocdS5cpwXQXVzmmh5e5+saE2QGoeQmbKmRS6J3VQppPOIt0MnmE+4xlZoumy0GPG0D0MVIQbNA1A=="
+      "version": "4.17.19",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.19.tgz",
+      "integrity": "sha512-JNvd8XER9GQX0v2qJgsaN/mzFCNA5BRe/j8JN9d+tWyGLSodKQHKFicdwNYzWwI3wjRnaKPsGj1XkBjx/F96DQ=="
     },
     "lodash._getnative": {
       "version": "3.9.1",

--- a/client/package.json
+++ b/client/package.json
@@ -12,7 +12,7 @@
     "css-time": "^0.1.12",
     "deep-equal": "^2.0.1",
     "immutability-helper": "^2.9.1",
-    "lodash": "^4.17.15",
+    "lodash": "^4.17.19",
     "mathjs": "^3.18.1",
     "memoize-one": "^4.0.3",
     "randomstring": "^1.1.5",
@@ -61,7 +61,7 @@
     "jest-diff": "^23.6.0",
     "jest-get-type": "^22.4.3",
     "jest-matcher-deep-close-to": "^1.3.0",
-    "jquery": "^3.4.1",
+    "jquery": "^3.5.1",
     "why-did-you-update": "^0.1.1"
   },
   "browserslist": {

--- a/client/src/containers/MathScopeContext/components/MathScopeContext.js
+++ b/client/src/containers/MathScopeContext/components/MathScopeContext.js
@@ -11,6 +11,7 @@ export class MathScopeProvider extends PureComponent {
     parser: PropTypes.instanceOf(Parser).isRequired,
     scopeEvaluator: PropTypes.instanceOf(ScopeEvaluator).isRequired,
     idsByName: PropTypes.objectOf(PropTypes.string).isRequired,
+    allSymbolIds: PropTypes.arrayOf(PropTypes.string).isRequired,
     scope: PropTypes.object.isRequired,
     scopeDiff: PropTypes.object.isRequired,
     errors: PropTypes.object.isRequired,
@@ -23,14 +24,19 @@ export class MathScopeProvider extends PureComponent {
   }
 
   componentDidUpdate(prevProps) {
-    const { errors, idsByName, setError, errorsDiff } = this.props
-
+    const { errors, idsByName, setError, errorsDiff, allSymbolIds } = this.props
+    const symbolIds = new Set(allSymbolIds);
     // delete old errors if no longer present
     // Need to use previous idsByName prop in case
     // the variable got deleted or its name has changed
     // Note: if name changed, we might be re-adding the error below
+    // Note: idsByName only includes uniquely named symbol ids.
     const prevIdsByName = prevProps.idsByName
     errorsDiff.deleted
+      .filter(name => {
+        // check that the symbol still exists; if it was deleted, we do not need to unset the error
+        return symbolIds.has(prevIdsByName[name])
+      })
       .forEach(name => {
         const errorData = new EvalErrorData(null)
         setError(prevIdsByName[name], 'value', errorData)

--- a/client/src/containers/MathScopeContext/index.js
+++ b/client/src/containers/MathScopeContext/index.js
@@ -6,11 +6,12 @@ export { MathScopeConsumer } from './components/MathScopeContext'
 
 // TODO: This updates when it does not need to because of parseErrors
 const mapStateToProps = ( { mathSymbols, sliderValues }, ownProps) => {
-  const { symbols, idsByName } = getParseableSymbols(ownProps.parser, mathSymbols, sliderValues)
+  const { symbols, idsByName, allSymbolIds } = getParseableSymbols(ownProps.parser, mathSymbols, sliderValues)
   const evaluationResult = ownProps.scopeEvaluator.evalScope(symbols)
   window.evaluationResult = evaluationResult
   return {
     idsByName,
+    allSymbolIds,
     ...evaluationResult
   }
 }

--- a/client/src/containers/MathScopeContext/selectors.js
+++ b/client/src/containers/MathScopeContext/selectors.js
@@ -2,7 +2,11 @@ import VariableSlider from 'containers/MathObjects/MathSymbols/VariableSlider'
 import memoizeOne from 'memoize-one'
 
 function _getParseableSymbols(parser, mathSymbols, sliderValues) {
-  const initial = { symbols: {}, idsByName: {} }
+  const initial = {
+    symbols: {},
+    idsByName: {},
+    allSymbolIds: Object.keys(mathSymbols),
+  }
   const seen = new Set()
   return Object.keys(mathSymbols).reduce((acc, id) => {
     const { name: lhs, value, type } = mathSymbols[id]

--- a/server/package-lock.json
+++ b/server/package-lock.json
@@ -922,9 +922,9 @@
       }
     },
     "acorn": {
-      "version": "6.6.1",
-      "resolved": "https://registry.npmjs.org/acorn/-/acorn-6.3.0.tgz",
-      "integrity": "sha512-/czfa8BwS88b9gWQVhc8eknunSA2DoJpJyTQkhheIf5E48u1N0R4q/YxxsAeqRrmK9TQ/uYfgLDfZo91UlANIA=="
+      "version": "6.4.1",
+      "resolved": "https://registry.npmjs.org/acorn/-/acorn-6.4.1.tgz",
+      "integrity": "sha512-ZVA9k326Nwrj3Cj9jlh3wGFutC2ZornPNARZwsNYqQYgN0EsV2d53w5RN/co65Ohn4sUAUtb1rSUAOD6XN9idA=="
     },
     "acorn-jsx": {
       "version": "5.0.2",
@@ -4990,6 +4990,12 @@
         "sha.js": "^2.4.8"
       }
     },
+    "picomatch": {
+      "version": "2.2.2",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.2.2.tgz",
+      "integrity": "sha512-q0M/9eZHzmr0AulXyPwNfZjtwZ/RBZlbN3K3CErVrk50T2ASYI7Bye0EvekFY3IP1Nt2DHu0re+V2ZHIpMkuWg==",
+      "optional": true
+    },
     "pidtree": {
       "version": "0.3.0",
       "resolved": "https://registry.npmjs.org/pidtree/-/pidtree-0.3.0.tgz",
@@ -6467,13 +6473,123 @@
       "integrity": "sha512-iq+S7vZJE60yejDYM0ek6zg308+UZsdtPExWP9VZoCFCz1zkJoXFnAX7aZfd/ZwrkidzdUZL0C/ryW+JwAiIGw=="
     },
     "watchpack": {
-      "version": "1.6.0",
-      "resolved": "https://registry.npmjs.org/watchpack/-/watchpack-1.6.0.tgz",
-      "integrity": "sha512-i6dHe3EyLjMmDlU1/bGQpEw25XSjkJULPuAVKCbNRefQVq48yXKUpwg538F7AZTf9kyr57zj++pQFltUa5H7yA==",
+      "version": "1.7.4",
+      "resolved": "https://registry.npmjs.org/watchpack/-/watchpack-1.7.4.tgz",
+      "integrity": "sha512-aWAgTW4MoSJzZPAicljkO1hsi1oKj/RRq/OJQh2PKI2UKL04c2Bs+MBOB+BBABHTXJpf9mCwHN7ANCvYsvY2sg==",
       "requires": {
-        "chokidar": "^2.0.2",
+        "chokidar": "^3.4.1",
         "graceful-fs": "^4.1.2",
-        "neo-async": "^2.5.0"
+        "neo-async": "^2.5.0",
+        "watchpack-chokidar2": "^2.0.0"
+      },
+      "dependencies": {
+        "anymatch": {
+          "version": "3.1.1",
+          "resolved": "https://registry.npmjs.org/anymatch/-/anymatch-3.1.1.tgz",
+          "integrity": "sha512-mM8522psRCqzV+6LhomX5wgp25YVibjh8Wj23I5RPkPppSVSjyKD2A2mBJmWGa+KN7f2D6LNh9jkBCeyLktzjg==",
+          "optional": true,
+          "requires": {
+            "normalize-path": "^3.0.0",
+            "picomatch": "^2.0.4"
+          }
+        },
+        "binary-extensions": {
+          "version": "2.1.0",
+          "resolved": "https://registry.npmjs.org/binary-extensions/-/binary-extensions-2.1.0.tgz",
+          "integrity": "sha512-1Yj8h9Q+QDF5FzhMs/c9+6UntbD5MkRfRwac8DoEm9ZfUBZ7tZ55YcGVAzEe4bXsdQHEk+s9S5wsOKVdZrw0tQ==",
+          "optional": true
+        },
+        "braces": {
+          "version": "3.0.2",
+          "resolved": "https://registry.npmjs.org/braces/-/braces-3.0.2.tgz",
+          "integrity": "sha512-b8um+L1RzM3WDSzvhm6gIz1yfTbBt6YTlcEKAvsmqCZZFw46z626lVj9j1yEPW33H5H+lBQpZMP1k8l+78Ha0A==",
+          "optional": true,
+          "requires": {
+            "fill-range": "^7.0.1"
+          }
+        },
+        "chokidar": {
+          "version": "3.4.1",
+          "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-3.4.1.tgz",
+          "integrity": "sha512-TQTJyr2stihpC4Sya9hs2Xh+O2wf+igjL36Y75xx2WdHuiICcn/XJza46Jwt0eT5hVpQOzo3FpY3cj3RVYLX0g==",
+          "optional": true,
+          "requires": {
+            "anymatch": "~3.1.1",
+            "braces": "~3.0.2",
+            "fsevents": "~2.1.2",
+            "glob-parent": "~5.1.0",
+            "is-binary-path": "~2.1.0",
+            "is-glob": "~4.0.1",
+            "normalize-path": "~3.0.0",
+            "readdirp": "~3.4.0"
+          }
+        },
+        "fill-range": {
+          "version": "7.0.1",
+          "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-7.0.1.tgz",
+          "integrity": "sha512-qOo9F+dMUmC2Lcb4BbVvnKJxTPjCm+RRpe4gDuGrzkL7mEVl/djYSu2OdQ2Pa302N4oqkSg9ir6jaLWJ2USVpQ==",
+          "optional": true,
+          "requires": {
+            "to-regex-range": "^5.0.1"
+          }
+        },
+        "fsevents": {
+          "version": "2.1.3",
+          "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.1.3.tgz",
+          "integrity": "sha512-Auw9a4AxqWpa9GUfj370BMPzzyncfBABW8Mab7BGWBYDj4Isgq+cDKtx0i6u9jcX9pQDnswsaaOTgTmA5pEjuQ==",
+          "optional": true
+        },
+        "glob-parent": {
+          "version": "5.1.1",
+          "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-5.1.1.tgz",
+          "integrity": "sha512-FnI+VGOpnlGHWZxthPGR+QhR78fuiK0sNLkHQv+bL9fQi57lNNdquIbna/WrfROrolq8GK5Ek6BiMwqL/voRYQ==",
+          "optional": true,
+          "requires": {
+            "is-glob": "^4.0.1"
+          }
+        },
+        "is-binary-path": {
+          "version": "2.1.0",
+          "resolved": "https://registry.npmjs.org/is-binary-path/-/is-binary-path-2.1.0.tgz",
+          "integrity": "sha512-ZMERYes6pDydyuGidse7OsHxtbI7WVeUEozgR/g7rd0xUimYNlvZRE/K2MgZTjWy725IfelLeVcEM97mmtRGXw==",
+          "optional": true,
+          "requires": {
+            "binary-extensions": "^2.0.0"
+          }
+        },
+        "is-number": {
+          "version": "7.0.0",
+          "resolved": "https://registry.npmjs.org/is-number/-/is-number-7.0.0.tgz",
+          "integrity": "sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng==",
+          "optional": true
+        },
+        "readdirp": {
+          "version": "3.4.0",
+          "resolved": "https://registry.npmjs.org/readdirp/-/readdirp-3.4.0.tgz",
+          "integrity": "sha512-0xe001vZBnJEK+uKcj8qOhyAKPzIT+gStxWr3LCB0DwcXR5NZJ3IaC+yGnHCYzB/S7ov3m3EEbZI2zeNvX+hGQ==",
+          "optional": true,
+          "requires": {
+            "picomatch": "^2.2.1"
+          }
+        },
+        "to-regex-range": {
+          "version": "5.0.1",
+          "resolved": "https://registry.npmjs.org/to-regex-range/-/to-regex-range-5.0.1.tgz",
+          "integrity": "sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ==",
+          "optional": true,
+          "requires": {
+            "is-number": "^7.0.0"
+          }
+        }
+      }
+    },
+    "watchpack-chokidar2": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/watchpack-chokidar2/-/watchpack-chokidar2-2.0.0.tgz",
+      "integrity": "sha512-9TyfOyN/zLUbA288wZ8IsMZ+6cbzvsNyEzSBp6e/zkifi6xxbl8SmQ/CxQq32k8NNqrdVEVUVSEf56L4rQ/ZxA==",
+      "optional": true,
+      "requires": {
+        "chokidar": "^2.1.8"
       }
     },
     "webpack": {


### PR DESCRIPTION
Resolves #250 


@stardust66 I decided to go a slightly different route than https://github.com/ChristopherChudzicki/math3d-react/commit/1796f01768ea3dc512f68c977e8928c04b16c10a. For context, there are 3 types of errors:

1. parse: errors that occur when math expressions are parsed
2 eval: errors that occur when math expressions are evaluated
3. render: parsing and eval has occurred correctly, but something has gone wrong in render. (E.g., a parametric curve evaluated to a vector with 4 components instead of 3)

Error types 1 and 2 can occur for any math expression: a symbol or any calculated expression for a graphics object (the main field, the range fields, any of the calculated options, e.g., size).

The error you found should only ever happen in exactly the situation you said: deleting math symbols with an eval error. 

So:

- Since we understand why `state[id]` is undefined in this specific case, we can check that up-front before dispatching the action
- I would not expect `state[id]` to ever be undefined in any other cases, since I do not think that `unset_error` should be dispatched after a math object is deleted. So if `state[id]` is ever undefined in any other cases, I will be surprised and would like to see an actual error message.

Thanks again for finding this bug and narrowing down the cause! 
