### PR TITLE
Better complex

### DIFF
--- a/client/src/components/MathBox/MathBoxComponents.js
+++ b/client/src/components/MathBox/MathBoxComponents.js
@@ -4,8 +4,8 @@ import math from 'utils/mathjs'
 import {
   validateBoolean,
   isEqualNumerically,
-  isNumeric,
-  validateNumeric,
+  isReal,
+  validateReal,
   validateVector,
   isVector,
   validateFunctionSignature,
@@ -201,10 +201,10 @@ function makeSetProperty(propName, validator: ?Function) {
 }
 
 const universalHandlers = {
-  opacity: makeSetProperty('opacity', validateNumeric),
-  zBias: makeSetProperty('zBias', validateNumeric),
-  zIndex: makeSetProperty('zIndex', validateNumeric),
-  zOrder: makeSetProperty('zOrder', validateNumeric),
+  opacity: makeSetProperty('opacity', validateReal),
+  zBias: makeSetProperty('zBias', validateReal),
+  zIndex: makeSetProperty('zIndex', validateReal),
+  zOrder: makeSetProperty('zOrder', validateReal),
   color: makeSetProperty('color'),
   calculatedVisibility: function(nodes: HandlerNodes, props: Props) {
     const { calculatedVisibility, useCalculatedVisibility } = props
@@ -221,8 +221,8 @@ const universalHandlers = {
 }
 
 const lineLikeHandlers = {
-  size: makeSetProperty('size', validateNumeric),
-  width: makeSetProperty('width', validateNumeric),
+  size: makeSetProperty('size', validateReal),
+  width: makeSetProperty('width', validateReal),
   start: makeSetProperty('start'),
   end: makeSetProperty('end')
 }
@@ -468,7 +468,7 @@ export class Axis extends AbstractMBC implements MathBoxComponent {
 
   static handleScale(nodes: HandlerNodes, handledProps: HandledProps) {
     const { scale, axis } = handledProps
-    validateNumeric(scale)
+    validateReal(scale)
     const cartesian = Axis.getCartesian(nodes.renderNodes)
     const scaleCopy = { ...cartesian.props.scale }
     scaleCopy[axis] = scale
@@ -486,14 +486,14 @@ export class Axis extends AbstractMBC implements MathBoxComponent {
 
   static handleMin(nodes: HandlerNodes, handledProps: HandledProps) {
     const { min, axis } = handledProps
-    validateNumeric(min)
+    validateReal(min)
     const cartesian = Axis.getCartesian(nodes.renderNodes)
     Axis.setAxisEnd(cartesian, axis, min, 0)
   }
 
   static handleMax(nodes: HandlerNodes, handledProps: HandledProps) {
     const { max, axis } = handledProps
-    validateNumeric(max)
+    validateReal(max)
     const cartesian = Axis.getCartesian(nodes.renderNodes)
     Axis.setAxisEnd(cartesian, axis, max, 1)
 
@@ -732,7 +732,7 @@ export class ParametricCurve extends AbstractMBC implements MathBoxComponent {
 
   static handleSamples(nodes: HandlerNodes, handledProps: HandledProps) {
     const { samples } = handledProps
-    validateNumeric(samples)
+    validateReal(samples)
     nodes.dataNodes.set('width', samples)
   }
 
@@ -812,32 +812,32 @@ export class ParametricSurface extends AbstractMBC implements MathBoxComponent {
   static handleGridOpacity(nodes: HandlerNodes, handledProps: HandledProps) {
     const { gridOpacity } = handledProps
     const { groupNode } = nodes
-    validateNumeric(gridOpacity)
+    validateReal(gridOpacity)
     groupNode.select('line').set('opacity', gridOpacity)
   }
 
   static handleGridWidth(nodes: HandlerNodes, handledProps: HandledProps) {
     const { gridWidth } = handledProps
     const { groupNode } = nodes
-    validateNumeric(gridWidth)
+    validateReal(gridWidth)
     groupNode.select('line').set('width', gridWidth)
   }
 
   static handleGridU(nodes: HandlerNodes, handledProps: HandledProps) {
     const { gridU } = handledProps
-    validateNumeric(gridU)
+    validateReal(gridU)
     nodes.groupNode.select('.gridU resample').set('width', gridU)
   }
   static handleGridV(nodes: HandlerNodes, handledProps: HandledProps) {
     const { gridV } = handledProps
-    validateNumeric(gridV)
+    validateReal(gridV)
     nodes.groupNode.select('.gridV resample').set('height', gridV)
   }
 
   static handleUSamples(nodes: HandlerNodes, handledProps: HandledProps, handlers: Handlers) {
     const { groupNode } = nodes
     const { uSamples } = handledProps
-    validateNumeric(uSamples)
+    validateReal(uSamples)
     const area = groupNode.select('area')
     const colorsNode = groupNode.select('.colors')
     if (area.get('width') === null) {
@@ -852,7 +852,7 @@ export class ParametricSurface extends AbstractMBC implements MathBoxComponent {
   static handleVSamples(nodes: HandlerNodes, handledProps: HandledProps, handlers: Handlers) {
     const { groupNode } = nodes
     const { vSamples } = handledProps
-    validateNumeric(vSamples)
+    validateReal(vSamples)
     const area = groupNode.select('area')
     const colorsNode = groupNode.select('.colors')
     if (area.get('height') === null) {
@@ -929,7 +929,7 @@ export class ParametricSurface extends AbstractMBC implements MathBoxComponent {
     const { colorExpr, color, expr, uSamples, vSamples, rangeU, rangeV } = handledProps
     if (!hasFunctionSignature(colorExpr, 5, 1)) { return false }
     if (!colorMaps[color] ) { return false }
-    if (!isNumeric(uSamples) || !isNumeric(vSamples)) { return false }
+    if (!isReal(uSamples) || !isReal(vSamples)) { return false }
     if (!this.constructor.isExprValid(expr)) { return false }
     if (!ParametricSurface.isRangeValid(rangeU, rangeV)) { return false }
     return true
@@ -1211,7 +1211,7 @@ export class ImplicitSurface extends AbstractMBC implements MathBoxComponent {
 
   static handleSamples(nodes: HandlerNodes, handledProps: HandledProps) {
     const { samples } = handledProps
-    validateNumeric(samples)
+    validateReal(samples)
     ImplicitSurface.updateData(nodes, handledProps)
   }
 
@@ -1223,7 +1223,7 @@ export class ImplicitSurface extends AbstractMBC implements MathBoxComponent {
       isVector(rangeZ, 2) &&
       hasFunctionSignature(lhs, 3, 1) &&
       hasFunctionSignature(rhs, 3, 1) &&
-      isNumeric(samples)
+      isReal(samples)
     )
   }
 
@@ -1312,7 +1312,7 @@ export class VectorField extends AbstractMBC implements MathBoxComponent {
 
   static handleScale(nodes: HandlerNodes, handledProps: HandledProps) {
     const { scale } = handledProps
-    isNumeric(scale)
+    isReal(scale)
     VectorField.updateRangeAndExpr(nodes, handledProps)
   }
 
@@ -1322,7 +1322,7 @@ export class VectorField extends AbstractMBC implements MathBoxComponent {
       isVector(rangeY, 2) &&
       isVector(rangeZ, 2) &&
       isVector(samples, 3) &&
-      isNumeric(scale) &&
+      isReal(scale) &&
       hasFunctionSignature(expr, 3, 3)
     )
   }

--- a/client/src/components/MathBox/helpers.js
+++ b/client/src/components/MathBox/helpers.js
@@ -22,19 +22,19 @@ export function isEqualNumerically(obj1: mixed, obj2: mixed): bool {
 
 }
 
-export function isNumeric(value: mixed) {
+export function isReal(value: mixed) {
   return typeof value === 'number'
 }
 
-export function validateNumeric(value: mixed) {
-  if (isNumeric(value)) { return }
-  throw TypeError(`Expected value to be a number, but it was an ${typeof value}`)
+export function validateReal(value: mixed) {
+  if (isReal(value)) { return }
+  throw TypeError(`Expected value to be a real number, but it was an ${typeof value}`)
 }
 
 export function isVector(value: mixed, numComponents: number) {
   if (value instanceof Array) {
     if (value.length !== numComponents) { return false }
-    return value.every(x => isNumeric(x))
+    return value.every(x => isReal(x))
   }
   return false
 }
@@ -45,7 +45,7 @@ export function validateVector(value: mixed, numComponents: number) {
 }
 
 // Validate that func is a function from R^numInputs to R^numpOutputs
-export function validateFunctionSignature(func: mixed, numInputs: number, numOutputs: number) {
+export function validateFunctionSignature(func: mixed, numInputs: number, numOutputs: number,) {
   if (!(typeof func === 'function')) {
     throw TypeError(`Expected a function, but received a ${typeof func}`)
   }
@@ -58,7 +58,7 @@ export function validateFunctionSignature(func: mixed, numInputs: number, numOut
   const result = func(...theArgs) // if func throws, well... then that's the error!
 
   if (numOutputs === 1) {
-    if (isNumeric(result) || result instanceof math.type.Complex) {
+    if (isReal(result) || result instanceof math.type.Complex) {
       return
     }
     throw TypeError('Expected function to return a number, but it did not.')

--- a/client/src/components/MathBox/helpers.js
+++ b/client/src/components/MathBox/helpers.js
@@ -31,20 +31,26 @@ export function validateReal(value: mixed) {
   throw TypeError(`Expected value to be a real number, but it was an ${typeof value}`)
 }
 
-export function isVector(value: mixed, numComponents: number) {
+export function isComplex(value: mixed) {
+  if (isReal(value)) return true
+  return value instanceof math.type.Complex
+}
+
+export function isVector(value: mixed, numComponents: number, { real = true }: { real: boolean } = {}) {
   if (value instanceof Array) {
     if (value.length !== numComponents) { return false }
-    return value.every(x => isReal(x))
+    return real ? value.every(x => isReal(x)) : value.every(x => isComplex(x))
   }
   return false
 }
 
-export function validateVector(value: mixed, numComponents: number) {
-  if (isVector(value, numComponents)) { return }
-  throw TypeError(`Expected value to be a ${numComponents}-component vector, but it is not.`)
+export function validateVector(value: mixed, numComponents: number, { real = true }: { real: boolean } = {}) {
+  if (isVector(value, numComponents, { real })) { return }
+  const type = real ? 'real ' : ''
+  throw TypeError(`Expected value to be a ${numComponents}-component ${type}vector, but it is not.`)
 }
 
-// Validate that func is a function from R^numInputs to R^numpOutputs
+// Validate that func is a function from C^numInputs to C^numpOutputs
 export function validateFunctionSignature(func: mixed, numInputs: number, numOutputs: number,) {
   if (!(typeof func === 'function')) {
     throw TypeError(`Expected a function, but received a ${typeof func}`)
@@ -58,13 +64,13 @@ export function validateFunctionSignature(func: mixed, numInputs: number, numOut
   const result = func(...theArgs) // if func throws, well... then that's the error!
 
   if (numOutputs === 1) {
-    if (isReal(result) || result instanceof math.type.Complex) {
+    if (isComplex(result)) {
       return
     }
     throw TypeError('Expected function to return a number, but it did not.')
   }
   if (numOutputs > 1) {
-    if (isVector(result, numOutputs)) {
+    if (isVector(result, numOutputs, { real: false })) {
       return
     }
     throw TypeError(`Expected function to return a vector of length ${numOutputs}, but it did not.`)

--- a/client/src/containers/MathObjects/containers/MathInput/components/validators.js
+++ b/client/src/containers/MathObjects/containers/MathInput/components/validators.js
@@ -65,7 +65,7 @@ export function isAssignment(parser, latexLHS, { latexRHS } ) {
   }
 }
 
-export function isNumeric(parser, latex) {
+export function isReal(parser, latex) {
   if (isNaN(latex)) {
     return new ParseErrorData(`Value Error: ${latex} is not a plain number`)
   }

--- a/client/src/containers/MathObjects/containers/MathInput/components/validators.test.js
+++ b/client/src/containers/MathObjects/containers/MathInput/components/validators.test.js
@@ -2,7 +2,7 @@ import {
   isAssignmentRHS,
   isAssignmentLHS,
   isValidName,
-  isNumeric
+  isReal
 } from './validators'
 import { Parser } from 'utils/mathParsing'
 import { ParseErrorData } from 'services/errors'
@@ -94,15 +94,15 @@ describe('isNameValid', () => {
   } )
 } )
 
-describe('isNumeric', () => {
+describe('isReal', () => {
   it('should mark numbers as valid', () => {
     const parser = null
-    expect(isNumeric(parser, '4.3')).toEqual(new ParseErrorData(null))
+    expect(isReal(parser, '4.3')).toEqual(new ParseErrorData(null))
   } )
 
   it('should mark non-numbers as invalid', () => {
     const parser = null
-    expect(isNumeric(parser, '4.3.1')).toEqual(
+    expect(isReal(parser, '4.3.1')).toEqual(
       new ParseErrorData('Value Error: 4.3.1 is not a plain number')
     )
   } )


### PR DESCRIPTION
Resolves the following issue:

1. Add parametric curve [sqrt(t^2-1), 0, t] and plot over any range
2. Continue adjusting the function. At some point, you'll get an eval error declaring the function has incorrect signature.

This occurred because we validate function signatures by random sampling AND we were requiring vector-valued functions to have real values. (Scalar-valued functions were allowed to be complex). This PR makes vector-valued functions allowed to be complex.

Note: Mathbox still will not plot functions with imaginary parts, but this makes this at least prevents erroneous error messages when you are plotting functions that have imaginary parts over some range.