### PR TITLE
Handle variables with multi-character subscripts

### DIFF
--- a/client/src/utils/mathParsing/preprocessors/preprocessMathQuill.js
+++ b/client/src/utils/mathParsing/preprocessors/preprocessMathQuill.js
@@ -40,9 +40,30 @@ export default function mathquillToMathJS(fromMQ: string) {
 
   // remove fractions, then apply replacements
   const noFrac = fracToDivision(fromMQ)
+  const noBraceSub = convertSubscript(noFrac)
   return replacements.reduce(
     (acc, r) => replaceAll(acc, r['tex'], r['mathjs'] ),
-    noFrac)
+    noBraceSub)
+}
+
+/**
+ * Recursively removes braces from LaTeX subscripts
+ *   - example: x_{12foo_{bar123_{evenlower}}} --> x_12foo_bar123_evenlower
+ */
+export function convertSubscript(expr: string) {
+  const sub = '_{'
+  const subStart = expr.indexOf(sub)
+
+  if (subStart < 0) { return expr }
+
+  const numStart = subStart + sub.length
+  const closingBrace = expr.indexOf('}', numStart)
+  const newExpr = expr.slice(0, subStart) +
+    '_' +
+    expr.slice(numStart, closingBrace) +
+    expr.slice(closingBrace + 1)
+
+  return convertSubscript(newExpr)
 }
 
 /**

--- a/client/src/utils/mathParsing/preprocessors/preprocessMathQuill.test.js
+++ b/client/src/utils/mathParsing/preprocessors/preprocessMathQuill.test.js
@@ -1,4 +1,4 @@
-import preprocessMathQuill, { fracToDivision } from './preprocessMathQuill'
+import preprocessMathQuill, { fracToDivision, convertSubscript } from './preprocessMathQuill'
 
 describe('fracToDivision', () => {
   test('converts zero fractions correctly', () => {
@@ -20,6 +20,26 @@ describe('fracToDivision', () => {
   } )
 } )
 
+describe('convertSubscript', () => {
+  test('does nothing to single character subscripts', () => {
+    const input = 'x_1 + x_2'
+    const expected = 'x_1 + x_2'
+    expect(convertSubscript(input)).toBe(expected)
+  } )
+
+  test('converts multi-character subscripts', () => {
+    const input = 'x_{12foo} + y_{bar123}'
+    const expected = 'x_12foo + y_bar123'
+    expect(convertSubscript(input)).toBe(expected)
+  } )
+
+  test('converts nested subscripts', () => {
+    const input = 'x_{12foo_{bar123_{evenlower}}}'
+    const expected = 'x_12foo_bar123_evenlower'
+    expect(convertSubscript(input)).toBe(expected)
+  } )
+} )
+
 describe('preprocessMathQuill', () => {
   test('fractions converted', () => {
     const input = 'a + \\frac{b + \\frac{c+d}{e+f}}{g+h}'
@@ -30,6 +50,18 @@ describe('preprocessMathQuill', () => {
   test('backslashes are removed', () => {
     const input = '1 + 3\\sin{\\pi x}'
     const expected = '1 + 3 sin( pi x)'
+    expect(preprocessMathQuill(input)).toBe(expected)
+  } )
+
+  test('multi-character subscripts converted', () => {
+    const input = 'x_{12}'
+    const expected = 'x_12'
+    expect(preprocessMathQuill(input)).toBe(expected)
+  } )
+
+  test('nested subscripts converted', () => {
+    const input = 'x_{12foo_{bar123_{evenlower}}}'
+    const expected = 'x_12foo_bar123_evenlower'
     expect(preprocessMathQuill(input)).toBe(expected)
   } )
 } )


### PR DESCRIPTION
Fixes #24.

Removes braces from multi-character subscripts so MathJS can parse them. Now we can do this:
![Screen Shot 2020-07-29 at 1 15 06 PM](https://user-images.githubusercontent.com/11802391/88832962-99e2bc00-d19f-11ea-82ab-51abd6575282.png)
