### PR TITLE
Fix legacy reroute crash

### DIFF
--- a/client/public/index.html
+++ b/client/public/index.html
@@ -14,11 +14,11 @@
       homescreen on Android. See https://developers.google.com/web/fundamentals/engage-and-retain/web-app-manifest/
     -->
     <!-- MathQuill -->
-    <script src="mathquill.min.js"></script>
-    <link rel="stylesheet" href="mathquill.css">
+    <script src="/mathquill.min.js"></script>
+    <link rel="stylesheet" href="/mathquill.css">
     <!-- MathBox -->
-    <script src="mathbox-bundle.min.js"></script>
-    <link rel="stylesheet" href="mathbox.css">
+    <script src="/mathbox-bundle.min.js"></script>
+    <link rel="stylesheet" href="/mathbox.css">
 
     <link rel="manifest" href="%PUBLIC_URL%/manifest.json">
     <link rel="shortcut icon" href="%PUBLIC_URL%/favicon.ico">


### PR DESCRIPTION
Fixes #260.

Change `src` of static javascript files to the root of the site.