### PR TITLE
Fix max/min functions causing eval error

### DIFF
--- a/client/src/containers/MathObjects/containers/MathInput/components/MathInput.js
+++ b/client/src/containers/MathObjects/containers/MathInput/components/MathInput.js
@@ -227,7 +227,7 @@ export default class MathInput extends React.PureComponent<Props, State> {
           onEdit={this.onEdit}
           size={this.props.size}
           autoCommands='sqrt pi theta phi'
-          autoOperatorNames='diff pdiff curl div unitT unitN unitB cosh sinh tanh arccosh arcsinh arctanh cos sin tan sec csc cot arcsin arccos arctan log ln exp mod abs norm'
+          autoOperatorNames='diff pdiff curl div unitT unitN unitB cosh sinh tanh arccosh arcsinh arctanh cos sin tan sec csc cot arcsin arccos arctan log ln exp mod abs norm max min'
         />
       </MathInputContainer>
     )

--- a/client/src/utils/mathjs/custom.js
+++ b/client/src/utils/mathjs/custom.js
@@ -9,6 +9,7 @@ math.import(require('mathjs/lib/constants'))
 math.import(require('mathjs/lib/function/arithmetic'))
 math.import(require('mathjs/lib/function/trigonometry'))
 math.import(require('mathjs/lib/function/matrix'))
+math.import(require('mathjs/lib/function/statistics'))
 
 math.import(require('mathjs/lib/expression'))
 


### PR DESCRIPTION
Fixes #264. Importing `mathjs/lib/function/statistics` adds `max` and `min` as keys of `window.math`, fixing the eval error. `max` and `min` are also added as operator names for MathQuill.