### PR TITLE
Move PaddingCover down so it does not block button

### DIFF
--- a/client/src/components/ScrollWithOverflow/index.js
+++ b/client/src/components/ScrollWithOverflow/index.js
@@ -65,7 +65,7 @@ const PaddingCover = styled.div`
   margin-right: -100vw;
   position: absolute;
   bottom:0;
-  top:0;
+  top: 65px;
 `
 
 function forwardEventToElement(domElement: HTMLElement, event: Event) {


### PR DESCRIPTION
Fixes #272. Move PaddingCover down by 65px, which is the hard-coded height of the tabs bar, so the tabs bar stops being blocked. Feels like a temporary fix but it works for now. Doesn't seem to break #269.