### PR TITLE
Fix Dragging to Empty Folders

### DIFF
--- a/client/src/components/SortableList/index.js
+++ b/client/src/components/SortableList/index.js
@@ -8,6 +8,12 @@ const DraggableItemContainer = styled.div`
   box-shadow: ${props => props.isDragging ? '0 0 5px gray' : ''}
 `
 
+const EmptyListIndicator = styled.div`
+  text-align: center;
+  user-select: none;
+  padding: 1em;
+`
+
 /**
  * SortableList, React Component
  *
@@ -54,13 +60,13 @@ export default function SortableList(props) {
             className={className}
             style={style}
           >
-            {props.items.map((item, index) => (
+            {props.items.length ? props.items.map((item, index) => (
               renderDraggableItem(
                 item,
                 renderItem,
                 { index, type: draggableType }
               )
-            ))}
+            )) : <EmptyListIndicator>Drag an object here to add it to this folder...</EmptyListIndicator>}
             {provided.placeholder}
           </div>
         )


### PR DESCRIPTION
This PR adds a small indicator under empty folders so that the Draggable area is not zero.

When dragging from above an empty folder, everything works fine. However, when dragging from below an empty folder, you need to drag the object past the Draggable area and onto the folder itself. I'm not too sure why that is, but I figure this is better than nothing.