### PR TITLE
Integral

### DIFF
--- a/client/package-lock.json
+++ b/client/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "math3d-react",
-  "version": "1.2.8",
+  "version": "1.2.9",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "math3d-react",
-      "version": "1.2.8",
+      "version": "1.2.9",
       "dependencies": {
         "antd": "^3.15.0",
         "babel-core": "^7.0.0-beta.41",
@@ -18,6 +18,7 @@
         "immutability-helper": "^2.9.1",
         "lodash": "^4.17.19",
         "mathjs": "^3.18.1",
+        "mathjs-simple-integral": "^0.1.1",
         "memoize-one": "^4.0.3",
         "randomstring": "^1.1.5",
         "re-reselect": "^2.3.0",
@@ -11782,6 +11783,14 @@
       },
       "engines": {
         "node": ">= 0.1"
+      }
+    },
+    "node_modules/mathjs-simple-integral": {
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/mathjs-simple-integral/-/mathjs-simple-integral-0.1.1.tgz",
+      "integrity": "sha512-g7op1S9kFiSTBWrYWn/C3NqxhycDPD3B9o/VmzpIj8OYzrY95eTiUWYqKEazWu1f1DmV8aCjcsjBGNNMWujldQ==",
+      "dependencies": {
+        "mathjs": "^3.18.1"
       }
     },
     "node_modules/md5.js": {
@@ -31983,6 +31992,14 @@
         "seed-random": "2.2.0",
         "tiny-emitter": "2.0.2",
         "typed-function": "0.10.7"
+      }
+    },
+    "mathjs-simple-integral": {
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/mathjs-simple-integral/-/mathjs-simple-integral-0.1.1.tgz",
+      "integrity": "sha512-g7op1S9kFiSTBWrYWn/C3NqxhycDPD3B9o/VmzpIj8OYzrY95eTiUWYqKEazWu1f1DmV8aCjcsjBGNNMWujldQ==",
+      "requires": {
+        "mathjs": "^3.18.1"
       }
     },
     "md5.js": {

--- a/client/package.json
+++ b/client/package.json
@@ -14,6 +14,7 @@
     "immutability-helper": "^2.9.1",
     "lodash": "^4.17.19",
     "mathjs": "^3.18.1",
+    "mathjs-simple-integral": "^0.1.1",
     "memoize-one": "^4.0.3",
     "randomstring": "^1.1.5",
     "re-reselect": "^2.3.0",

--- a/client/src/containers/MathObjects/containers/MathInput/MathTextOutput.js
+++ b/client/src/containers/MathObjects/containers/MathInput/MathTextOutput.js
@@ -19,6 +19,7 @@ class MathTextOutput extends React.PureComponent {
     this.renderTextOutput = this.renderTextOutput.bind(this)
     this.convertExponentNotation = this.convertExponentNotation.bind(this)
     this.deepConvert = this.deepConvert.bind(this)
+    this.convertComplexExponentNotation = this.convertComplexExponentNotation.bind(this)
   }
 
   render() {
@@ -33,8 +34,8 @@ class MathTextOutput extends React.PureComponent {
 
   // convert exponent notation to latex
   // example: '123e+12' => '123 \cdot 10^{12}' 
-  convertExponentNotation(raw) {
-    const string = Number.parseFloat(raw).toPrecision(12)
+  convertExponentNotation(number) {
+    const string = Number.parseFloat(number).toPrecision(12)
     const index = string.search(/e[+-]/)
     if(index < 0){
       return Number(string)
@@ -43,6 +44,16 @@ class MathTextOutput extends React.PureComponent {
     const exponent = Number(string.slice(index+1))
     if(exponent < -12)
     return `${Number(mantissa)} \\cdot 10^{${exponent}}`
+  }
+
+  convertComplexExponentNotation(complex) {
+      const real = this.convertExponentNotation(complex.re)
+      const imag = this.convertExponentNotation(complex.im)
+      const output = Math.abs(complex.re) < Math.abs(complex.im)/(10**12) ? `${imag}i` :
+        Math.abs(complex.im) < Math.abs(complex.re)/(10**12)? `${real}` : 
+        complex.im < 0 ? `${real}${imag}i` : `${real}+${imag}i`
+
+      return output
   }
 
   // convert every member of an array to latex exponent
@@ -55,10 +66,7 @@ class MathTextOutput extends React.PureComponent {
     }
 
     if(array instanceof math.type.Complex) {
-      const real = this.convertExponentNotation(array.re)
-      const imag = this.convertExponentNotation(array.im)
-      const output = real === '0' || Math.abs(array.re) < Math.abs(array.im)/(10**12) ? `${imag}i` :
-        Math.abs(array.im) < Math.abs(array.re)/(10**12)? `${real}` : `${real}+${imag}i`
+      const output = this.convertComplexExponentNotation(array)
       return output
     }
     return this.convertExponentNotation(array)
@@ -84,10 +92,7 @@ class MathTextOutput extends React.PureComponent {
     }
 
     else if(evaluatedValue instanceof math.type.Complex) {
-      const real = this.convertExponentNotation(evaluatedValue.re)
-      const imag = this.convertExponentNotation(evaluatedValue.im)
-      outputText = real === '0' || Math.abs(evaluatedValue.re) < Math.abs(evaluatedValue.im)/(10**12) ? `${imag}i` :
-        Math.abs(evaluatedValue.im) < Math.abs(evaluatedValue.re)/(10**12)? `${real}` : `${real}+${imag}i`
+      outputText = this.convertComplexExponentNotation(evaluatedValue)
     }
 
     else {

--- a/client/src/containers/MathObjects/containers/MathInput/components/MathInput.js
+++ b/client/src/containers/MathObjects/containers/MathInput/components/MathInput.js
@@ -226,8 +226,8 @@ export default class MathInput extends React.PureComponent<Props, State> {
           latex={this.props.latex}
           onEdit={this.onEdit}
           size={this.props.size}
-          autoCommands='sqrt pi theta phi'
-          autoOperatorNames='diff pdiff curl div unitT unitN unitB cosh sinh tanh arccosh arcsinh arctanh cos sin tan sec csc cot arcsin arccos arctan log ln exp mod abs norm max min re im arg conj'
+          autoCommands='sqrt pi theta phi int'
+          autoOperatorNames='diff pdiff curl div unitT unitN unitB cosh sinh tanh arccosh arcsinh arctanh cos sin tan sec csc cot arcsin arccos arctan log ln exp mod abs norm max min re im arg conj join'
         />
       </MathInputContainer>
     )

--- a/client/src/utils/helpers.js
+++ b/client/src/utils/helpers.js
@@ -82,7 +82,7 @@ export function findIntegralEnd(str: string, startIdx: number) {
     }
 
     /**
-    * TODO: add exceptions to skip operators, default functions (sin, cos, tan, ln, etc...)
+    * Exceptions to skip operators, default functions (sin, cos, tan, ln, etc...)
     * so that they won't be detected as the end of an integral
     * DONE!!
     * */

--- a/client/src/utils/helpers.js
+++ b/client/src/utils/helpers.js
@@ -49,3 +49,50 @@ export function findClosingBrace(str: string, startIdx: number) {
   // stack !== 0
   throw Error(`${str} has a brace that opens at position ${startIdx} but does not close.`)
 }
+
+export function findIntegralEnd(str: string, startIdx: number) {
+
+  const openingIntegral = '\\int'
+  const closingIntegral = 'd'
+
+  if (str.slice(startIdx, startIdx + 4) !== openingIntegral) {
+    throw Error(`${str} does not contain an opening of integral at position ${startIdx}.`)
+  }
+  const ownUpperBoundaryStart =  str.indexOf('^', startIdx) + 1
+  const start = str[ownUpperBoundaryStart] === '{' ? findClosingBrace(str, ownUpperBoundaryStart) + 1 : ownUpperBoundaryStart + 1
+
+  const strlen = str.length
+
+  let stack = 1
+
+  for (let j = start; j < strlen; j++) {
+    /**
+    * TODO: add exceptions to skip operator, default function (sin, cos, tan, ln, etc...)
+    * so that they won't be detected as end of integral
+    * */
+    if (str.slice(j,j+4) === openingIntegral) {
+      stack += 1
+      const upperBoundaryStart = str.indexOf('^', j)
+      const integrandStart = str[upperBoundaryStart] === '{' ? findClosingBrace(str, upperBoundaryStart) : upperBoundaryStart
+      j = integrandStart
+    }
+    else if (str[j] === closingIntegral && j + 1 < strlen) {
+      stack -= 1
+      //edge case for integral ddd
+      if (str.slice(j,j+3) === 'ddd') {
+        j += 1
+      }
+      if (stack === 0) {
+        return j
+      }
+      if (str[j+1] === '\\') {
+        j = str.indexOf(' ', j)
+      }
+      else {
+        j++
+      }
+    }  
+  }
+  //stack !== 0
+  throw Error(`cannot find end of integral.`)
+}

--- a/client/src/utils/helpers.js
+++ b/client/src/utils/helpers.js
@@ -66,26 +66,61 @@ export function findIntegralEnd(str: string, startIdx: number) {
   let stack = 1
 
   for (let j = start; j < strlen; j++) {
-    /**
-    * TODO: add exceptions to skip operator, default function (sin, cos, tan, ln, etc...)
-    * so that they won't be detected as end of integral
-    * */
+
     if (str.slice(j,j+4) === openingIntegral) {
       stack += 1
       const upperBoundaryStart = str.indexOf('^', j)
       const integrandStart = str[upperBoundaryStart] === '{' ? findClosingBrace(str, upperBoundaryStart) : upperBoundaryStart
-      j = integrandStart
+
+      //if there's a left bracket at the start of integrand, skip all the content of the brackets
+      if (str[integrandStart + 6] === '(') {
+        j = findClosingBrace(str, integrandStart + 6)
+      }
+      else {
+        j = integrandStart
+      }
     }
+
+    /**
+    * TODO: add exceptions to skip operators, default functions (sin, cos, tan, ln, etc...)
+    * so that they won't be detected as the end of an integral
+    * DONE!!
+    * */
+
+    if (str[j] === '\\') {
+      if (str.slice(j, j + 13) === '\\operatorname{') {
+        const operatorNameEnd = findClosingBrace(str, j + 13)
+        const operatorEnd = findClosingBrace(str, operatorNameEnd + 6)
+        j = operatorEnd
+        continue
+      }
+      else {
+        const endBySpace = str.indexOf(' ', j)
+        const endByBrackets = str.slice(j).search(/[({]/) + j
+
+        if (endBySpace > endByBrackets) {
+          j = endBySpace
+          continue
+        }
+        else {
+          j = findClosingBrace(str, endByBrackets)
+          continue
+        }
+
+      }
+    }
+
+
     else if (str[j] === closingIntegral && j + 1 < strlen) {
       stack -= 1
       //edge case for integral ddd
-      if (str.slice(j,j+3) === 'ddd') {
+      if (str.slice(j, j + 3) === 'ddd') {
         j += 1
       }
       if (stack === 0) {
         return j
       }
-      if (str[j+1] === '\\') {
+      if (str[j + 1] === '\\') {
         j = str.indexOf(' ', j)
       }
       else {

--- a/client/src/utils/helpers.test.js
+++ b/client/src/utils/helpers.test.js
@@ -1,7 +1,8 @@
 import {
   escapeRegExp,
   replaceAll,
-  findClosingBrace
+  findClosingBrace,
+  findIntegralEnd
 } from './helpers'
 
 test('escaping regular expressions', () => {
@@ -49,4 +50,43 @@ describe('findClosingBrace', () => {
       `${expression} has a brace that opens at position ${startIdx} but does not close.`
     )
   } )
+} )
+
+describe('findIntegralEnd', () => {
+  test('simple variable of integration with simple boundary', () => {
+    const expression = '10 + \\int_0^1\\int_0^1xdydx'
+    const startIdx = 5
+    expect(findIntegralEnd(expression, startIdx)).toBe(24)
+  } )
+
+  test('skip integration boundary', () => {
+    const expression = '\\int_0^ddx'
+    const startIdx = 0
+    expect(findIntegralEnd(expression, startIdx)).toBe(8)
+  } )
+  test('implicit integrand', () => {
+    const expression = '\\int_0^1\\int_0^1dudv'
+    const startIdx = 0
+    expect(findIntegralEnd(expression, startIdx)).toBe(18)
+  } )
+  
+  test('symbol variable of integration with symbol boundary', () => {
+    const expression = '5 + \\int_0^{\\alpha}2\\int_{\\beta}^1xd\\gammad d\\eta'
+    const startIdx = 4
+    expect(findIntegralEnd(expression, startIdx)).toBe(44)
+  } )
+
+  test('throw an error if starting index is not an integral', () => {
+    const expression = '\\int_0^1xdx'
+    const startIdx = 6
+    const badfunc = () => findIntegralEnd(expression, startIdx)
+    expect(badfunc).toThrow(`${expression} does not contain an opening of integral at position ${startIdx}.`)
+  } )
+
+  test('throw an error if no differentials', () => {
+    const expression = '\\int_0^1x'
+    const startIdx = 0
+    const badfunc = () => findIntegralEnd(expression, startIdx)
+    expect(badfunc).toThrow(`cannot find end of integral.`)
+  })
 } )

--- a/client/src/utils/mathParsing/MathExpression.js
+++ b/client/src/utils/mathParsing/MathExpression.js
@@ -66,6 +66,7 @@ export default class MathExpression {
 
   _getDependencies() {
     const dependencies: Set<string> = new Set()
+    const integralExceptions : Set<string> = new Set()
     const isAssignmentNode = (this.tree.type === 'AssignmentNode')
     const isFunctionAssignmentNode = (this.tree.type === 'FunctionAssignmentNode')
 
@@ -76,8 +77,15 @@ export default class MathExpression {
       ? this.tree.params
       : []
 
-    rhs.traverse((node: Node) => {
+    rhs.traverse((node: Node, path: string, parent: Node) => {
       if (node.type === 'SymbolNode' || node.type === 'FunctionNode') {
+        // make exceptions for integral variable 
+        if (parent) {
+          if (parent.name === 'integrate' && path === 'args[3]') {
+            integralExceptions.add(node.name)
+          }
+        }
+        
         if (!params.includes(node.name)) {
           dependencies.add(node.name)
         }
@@ -90,7 +98,7 @@ export default class MathExpression {
       }
     } )
 
-    return dependencies
+    return new Set<string>([...dependencies].filter(i => !integralExceptions.has(i)))
   }
 
   _getEval() {

--- a/client/src/utils/mathParsing/preprocessors/preprocessMathQuill.test.js
+++ b/client/src/utils/mathParsing/preprocessors/preprocessMathQuill.test.js
@@ -64,4 +64,34 @@ describe('preprocessMathQuill', () => {
     const expected = 'x_12foo_bar123_evenlower'
     expect(preprocessMathQuill(input)).toBe(expected)
   } )
+
+  test('integral converted', () => {
+    const input = '\\int _0^1xdx'
+    const expected = ' integrate( x, 0, 1, x)'
+    expect(preprocessMathQuill(input)).toBe(expected)
+  })
+
+  test('implicit integrand', () => {
+    const input = '\\int _0^1dx'
+    const expected = ' integrate( 1, 0, 1, x)'
+    expect(preprocessMathQuill(input)).toBe(expected)
+  })
+
+  test('integral with dot symbol converted', () => {
+    const input = '\\int _0^xx\\cdot udu'
+    const expected = ' integrate( 0, x, x* u, u)'
+    expect(preprocessMathQuill(input)).toBe(expected)
+  })
+
+  test('edge case integral ddd converted', () => {
+    const input = '\\int _0^1ddd'
+    const expected = ' integrate( d, 0, 1, d)'
+    expect(preprocessMathQuill(input)).toBe(expected)
+  })
+
+  test('nested integral converted', () => {
+    const input = '5 + \\int_0^{\\alpha}2\\int_{\\beta}^1xd\\gamma d\\eta'
+    const expected = '5 +  integrate( 2 integrate( x, ( beta), 1,  gamma) , 0, ( alpha),  eta)'
+    expect(preprocessMathQuill(input)).toBe(expected)
+  })
 } )

--- a/client/src/utils/mathParsing/preprocessors/preprocessMathQuill.test.js
+++ b/client/src/utils/mathParsing/preprocessors/preprocessMathQuill.test.js
@@ -79,7 +79,7 @@ describe('preprocessMathQuill', () => {
 
   test('integral with dot symbol converted', () => {
     const input = '\\int _0^xx\\cdot udu'
-    const expected = ' integrate( 0, x, x* u, u)'
+    const expected = ' integrate( x *  u, 0, x, u)'
     expect(preprocessMathQuill(input)).toBe(expected)
   })
 

--- a/client/src/utils/mathjs/custom.js
+++ b/client/src/utils/mathjs/custom.js
@@ -5,6 +5,7 @@ const math: Math = core.create()
 
 math.import(require('mathjs/lib/type/matrix'))
 math.import(require('mathjs/lib/type/complex'))
+math.import(require('mathjs/lib/type/fraction'))
 math.import(require('mathjs/lib/constants'))
 math.import(require('mathjs/lib/function/arithmetic'))
 math.import(require('mathjs/lib/function/trigonometry'))
@@ -13,5 +14,7 @@ math.import(require('mathjs/lib/function/matrix'))
 math.import(require('mathjs/lib/function/statistics'))
 
 math.import(require('mathjs/lib/expression'))
+
+math.import(require('mathjs-simple-integral'))
 
 export default math

--- a/client/src/utils/mathjs/index.js
+++ b/client/src/utils/mathjs/index.js
@@ -2,6 +2,7 @@
 import customMath from './custom'
 import { diff, pdiff, unitT, unitN, unitB, curl, div } from './derivatives'
 import { int } from './integral'
+import Integrator from './Integrator'
 
 function arctan(arg0: number, arg1?: number) {
   return arg1 === undefined ? customMath.atan(arg0) : customMath.atan2(arg0, arg1)
@@ -32,3 +33,5 @@ customMath.import( {
 export default customMath
 
 window.math = customMath
+
+export const integrator = new Integrator()

--- a/client/src/utils/mathjs/index.js
+++ b/client/src/utils/mathjs/index.js
@@ -1,6 +1,7 @@
 // @flow
 import customMath from './custom'
 import { diff, pdiff, unitT, unitN, unitB, curl, div } from './derivatives'
+import { int } from './integral'
 
 function arctan(arg0: number, arg1?: number) {
   return arg1 === undefined ? customMath.atan(arg0) : customMath.atan2(arg0, arg1)
@@ -8,6 +9,7 @@ function arctan(arg0: number, arg1?: number) {
 
 const imaginaryUnit = customMath.i
 customMath.import( {
+  int,
   diff,
   pdiff,
   unitT,

--- a/client/src/utils/mathjs/integral.js
+++ b/client/src/utils/mathjs/integral.js
@@ -1,0 +1,119 @@
+// @flow
+import type { Node } from './types'
+
+const STEP = 0.004
+
+/**
+ * Calculate the numeric integration of a function
+ * @param {Function} f
+ * @param {number} start
+ * @param {number} end
+ */
+function integrate (f: Function, start: number, end: number) {
+    let total = 0
+    let sign = 1
+    if (start > end) {
+        const starttemp = start
+        start = end
+        end = starttemp
+        sign = -1
+    }
+
+    for (let x = start; x < end; x += STEP) {
+        total += STEP*(f(x) + 4*f(x + STEP / 2) + f(x + STEP))/6
+    }
+    return sign*total
+}
+
+/**
+ * A transformation for the integrate function. This transformation will be
+ * invoked when the function is used via the expression parser of math.js.
+ *
+ * from https://mathjs.org/examples/advanced/custom_argument_parsing.js.html 
+ * with modifications
+ *
+ * Syntax:
+ *
+ *     integrate(integrand, start, end, variable)
+ *
+ * Usage:
+ *
+ *     math.evaluate('integrate(2*x, 0, 2, x)')
+ *
+ * @param {Array.<math.Node>} args
+ *            Expects the following arguments: [f, start, end, x]
+ * @param {Object} math
+ * @param {Object} [scope]
+ */
+integrate.transform = function (args, math, scope) {
+
+    // determine the variable name
+    if (!args[3].isSymbolNode) {
+        throw new Error('Integrating variable must be a symbol')
+    }
+    const variable = args[3].name
+
+    // check for integration bounds dependencies
+    if (getDependencies(args[1]).has(variable) || getDependencies(args[2]).has(variable)) {
+        throw Error(`Integration bounds can't depend on integration variable '${variable}'. `)
+    }
+
+    // evaluate start and end
+    const start = args[1].compile().eval(scope)
+    const end = args[2].compile().eval(scope)
+
+
+    // create a new scope, linked to the provided scope. We use this new scope
+    // to apply the variable.
+    const fnScope = Object.create(scope)
+
+    let F: Function
+    // try to execute integral with mathjs-simple-integral
+    try {        
+        const integrated = math.integral(args[0], args[3]).compile()
+        const _F = function (x) {
+            fnScope[variable] = x
+            console.log(integrated.eval(fnScope))
+            return integrated.eval(fnScope)
+        }
+
+        F = function (start, end) {
+            return _F(end) - _F(start)
+        }
+    }
+    catch {
+        // construct a function which evaluates the first parameter f after applying
+        // a value for parameter x.
+        const fnCode = args[0].compile()
+        const f = function (x) {
+            fnScope[variable] = x
+            return fnCode.eval(fnScope)
+        }
+
+        // execute the integration
+        F = function (start, end) {
+            return integrate(f, start, end)
+        }
+    }
+
+    return F(start, end)
+
+}
+
+// mark the transform function with a "rawArgs" property, so it will be called
+// with uncompiled, unevaluated arguments.
+integrate.transform.rawArgs = true
+
+export const int = { integrate: integrate }
+
+const getDependencies = (expr: Node) => {
+    const dependencies: Set<string> = new Set()
+
+    expr.traverse((node: Node) => {
+      if (node.type === 'SymbolNode' || node.type === 'FunctionNode') {
+        dependencies.add(node.name)
+      }
+    } )
+
+    return dependencies
+}

--- a/client/src/utils/mathjs/integral.js
+++ b/client/src/utils/mathjs/integral.js
@@ -47,6 +47,8 @@ function integrate (f: Function, start: number, end: number) {
  */
 integrate.transform = function (args, math, scope) {
 
+    console.log(args)
+
     // determine the variable name
     if (!args[3].isSymbolNode) {
         throw new Error('Integrating variable must be a symbol')
@@ -73,7 +75,6 @@ integrate.transform = function (args, math, scope) {
         const integrated = math.integral(args[0], args[3]).compile()
         const _F = function (x) {
             fnScope[variable] = x
-            console.log(integrated.eval(fnScope))
             return integrated.eval(fnScope)
         }
 

--- a/client/src/utils/mathjs/integrator.js
+++ b/client/src/utils/mathjs/integrator.js
@@ -1,28 +1,193 @@
 // @flow
 
-type IntegratedCache = {
-    [expr: string] : {
-        isNumeric: bool,
-        integratedFunction: Function
-    } | {
-        isNumeric: bool,
-        step: number,
-        integratedArray: Array<number>
-    }
+import type { Node } from 'utils/mathjs/types'
+
+type IntegratedCacheSimple = {|
+    isNumeric: bool,
+    integratedFunction: Function    
+|}
+
+type IntegratedCacheNumeric = {|
+    isNumeric: bool,
+    step: number,
+    lowerBound: number,
+    upperBound: number,
+    integratedArray: Array<number>
+|}
+
+type IntegratedCache = IntegratedCacheNumeric | IntegratedCacheSimple
+
+type IntegratedCaches = {
+    [name: string] : IntegratedCache
 }
+
 /**
-* TODO:
-* make an integrator class that can store cached function from mathjs-simple-integral or
+* Integrator class that can store cached function from mathjs-simple-integral or
 * array of numbers from numerical integration.
 * 
 * then the cached function or array can be retrieved or created if not already exist
 * by a function that recieve integral bounds, math, scope, and numerical integrate function 
-* 
-* 
-* 
+* AFAIK DONE!!
+* tho I didn't find a way to cache integral bounds, they only take about 0.1 sec per compilation
+* finding a way to cache integral bounds is especially hard when it comes to variable bounds.
 */
 
+const STEP = 0.001
 
 export default class Integrator {
-    _cache: IntegratedCache
+
+    _cache: IntegratedCaches = {}
+
+    getInt(expr: Node, lowerBound: number, upperBound: number, variable: string, math: Object, scope: Object, numericalIntegrator: Function) {
+
+        // the name of caches use both expression and variable, because both of them can change the undetermined integral
+        const name = `${expr.toString()} d${variable}`
+        
+        if (this._cache[name] === undefined) {
+            this.addToCache(expr, lowerBound, upperBound, variable, math, scope, numericalIntegrator)
+        }
+
+        // if the cached function is a numeric function (an array)
+        if (this._cache[name].isNumeric) {
+
+            let cached: IntegratedCacheNumeric = this._cache[name]
+
+            // if the boundaries are wider than current one, expand the cached array
+            if (Math.max(lowerBound, upperBound) > cached.upperBound || Math.min(lowerBound, upperBound) < cached.lowerBound) {
+
+                this.expandNumericInt(expr, lowerBound, upperBound, variable, scope, numericalIntegrator)
+            }
+
+            else {
+
+                // update cached variable after expanded
+                cached = this._cache[name]
+
+                const lowerIndex = Math.floor(( lowerBound - cached.lowerBound ) / cached.step)
+                const upperIndex = Math.floor(( upperBound - cached.lowerBound ) / cached.step)
+
+                return cached.integratedArray[upperIndex] - cached.integratedArray[lowerIndex]
+
+            }
+
+        }
+
+        // else, use the function that have been integrated by mathjs-simple-integral
+        else {
+
+            const { integratedFunction } = this._cache[name]
+
+            return integratedFunction(lowerBound, upperBound)
+
+        }
+
+    }
+
+    addToCache(expr: Node, lowerBound: number, upperBound: number, variable: string, math: Object, scope: Object, numericalIntegrator: Function) {
+        
+        // make copy of the scope to be modified
+        let fnScope = Object.create(scope)
+        const name = `${expr.toString()} d${variable.toString()}`
+
+        try {
+            // try to integrate using mathjs-simple-integral
+            const integrated = math.integral(expr, variable).compile()
+
+            // if successful make a new function from the integrated expression
+            const _F = function (x) {
+                fnScope[variable] = x
+                return integrated.eval(fnScope)
+            }
+
+            const F = function (start, end) {
+                return _F(end) - _F(start)
+            }
+
+            this._cache[name] = {
+                isNumeric: false,
+                integratedFunction: F
+
+            }
+        } catch (error) {
+
+            // if fails, use numerical integration
+
+            // construct a function which evaluates the first parameter f after applying
+            // a value for parameter x.
+            const fnCode = expr.compile()
+            const f = function (x) {
+                fnScope[variable] = x
+                return fnCode.eval(fnScope)
+            }
+
+            // execute the integration and get the integrated array, with expanded upper bound
+            const absoluteUpper = Math.max(lowerBound, upperBound)
+            const absoluteLower = Math.min(lowerBound, upperBound)
+            const integrated = numericalIntegrator(f, absoluteLower, absoluteUpper + 1, STEP)
+
+            this._cache[name] = {
+                isNumeric: true,
+                step: STEP,
+                lowerBound: absoluteLower,
+                upperBound: STEP * Math.ceil((absoluteUpper + 1) / STEP),
+                integratedArray: integrated
+            }
+
+        }
+
+    }
+
+    expandNumericInt(expr: Node, lowerBound: number, upperBound: number, variable: string, scope: Object, numericalIntegrator: Function) {
+        // construct a function which evaluates the first parameter f after applying
+        // a value for parameter x.
+        const name = `${expr.toString()} d${variable.toString()}`
+        const absoluteUpper = Math.max(lowerBound, upperBound)
+        const absoluteLower = Math.min(lowerBound, upperBound)
+
+        let fnScope = Object.create(scope)
+
+        const fnCode = expr.compile()
+        const f = function (x) {
+            fnScope[variable] = x
+            return fnCode.eval(fnScope)
+        }
+
+        let currentArray = this._cache[name].integratedArray
+
+        // check the need for expansion directions
+        const needUpward = absoluteUpper > this._cache[name].upperBound
+        const needDownward = absoluteLower < this._cache[name].lowerBound
+
+        // expand upward if needed
+        if (needUpward) {
+            let expandedUpper = numericalIntegrator(f, this._cache[name].upperBound, absoluteUpper + 1, STEP)
+            const currentUpperValue = currentArray[currentArray.length - 1]
+            expandedUpper = expandedUpper.map(value => value + currentUpperValue)
+            expandedUpper.shift()
+            currentArray.push(...expandedUpper)
+        }
+
+        // expand downward if needed
+        if (needDownward) {
+            const newLowerBound = this._cache[name].lowerBound - STEP * Math.ceil((this._cache[name].lowerBound - (absoluteLower - 1)) / STEP)
+            let expandedLower = numericalIntegrator(f, newLowerBound, this._cache[name].lowerBound, STEP)
+            const newLowerValue = expandedLower[expandedLower.length - 1]
+            currentArray = currentArray.map(value => value + newLowerValue)
+            currentArray.shift()
+            currentArray = [...expandedLower, ...currentArray]
+        }
+
+        //get new boundaries
+        const newLowerBound = needDownward? this._cache[name].lowerBound - STEP * Math.ceil((this._cache[name].lowerBound - (absoluteLower - 1)) / STEP) : this._cache[name].lowerBound
+        const newUpperBound = needUpward? STEP * Math.ceil((absoluteUpper + 1) / STEP) : this._cache[name].upperBound
+
+        this._cache[name] = {
+            isNumeric: true,
+            step: STEP,
+            lowerBound: newLowerBound,
+            upperBound: newUpperBound,
+            integratedArray: currentArray
+        }
+
+    }
 }

--- a/client/src/utils/mathjs/integrator.js
+++ b/client/src/utils/mathjs/integrator.js
@@ -1,0 +1,28 @@
+// @flow
+
+type IntegratedCache = {
+    [expr: string] : {
+        isNumeric: bool,
+        integratedFunction: Function
+    } | {
+        isNumeric: bool,
+        step: number,
+        integratedArray: Array<number>
+    }
+}
+/**
+* TODO:
+* make an integrator class that can store cached function from mathjs-simple-integral or
+* array of numbers from numerical integration.
+* 
+* then the cached function or array can be retrieved or created if not already exist
+* by a function that recieve integral bounds, math, scope, and numerical integrate function 
+* 
+* 
+* 
+*/
+
+
+export default class Integrator {
+    _cache: IntegratedCache
+}

--- a/client/src/utils/mathjs/types.js
+++ b/client/src/utils/mathjs/types.js
@@ -86,6 +86,7 @@ export type Math = {
   },
   eval: (string, ?Object) => Numeric | Function,
   import: (Object, ?Object) => void,
+  integral: (Node | string, SymbolNode<Node> | string) => Node,
   // TODO: The types below are too loose; e.g., add/subtract should both be
   // length-preserving polymorphic types; cross only works
   // with 3-component vectors, norm does not accept matrices


### PR DESCRIPTION
Hello, this PR will add support for integration, with mathjs-simple-integral and numerical. As I mentioned in this #323, I tried to implement a cache system, and it works as expected. In my laptop (i5-10th gen), it took about a second to process the integration system, with most of the time is used to compile integration boundaries (probably more than 80%), as I can't find a way to cache it.

I made several changes in :
- the preprocessor to process integration symbols
- mathjs to add the integration system
- mathinput to add int shortcut
- mathexpression to omit dependencies related to the integration variables

I also made minor changes in preprocessor for it to be able to process norm with vertical brackets, and add join operator to join list.

hope you like it 😁