### PR TITLE
Add justfile with `just start` for local dev

### DIFF
--- a/justfile
+++ b/justfile
@@ -1,0 +1,38 @@
+# math3d-react (legacy site) — local dev tasks.
+# Run `just` to list recipes.
+
+# Directory holding the create-react-app frontend (the only thing that matters locally).
+client_dir := "client"
+
+# Dev server port. Kept outside the 300-3010 range per project convention.
+port := "3141"
+
+# Local math3d-next (DRF) backend base URL for the legacy scenes endpoints.
+#   POST {base}          -> create scene
+#   GET  {base}{key}     -> retrieve scene
+# Requires `api.math3d.localdev` resolving to your local backend (e.g. /etc/hosts).
+next_api := "http://api.math3d.localdev:8000/v1/legacy_scenes/"
+
+# List available recipes.
+default:
+    @just --list
+
+# Install client dependencies if they're missing (fast no-op when present).
+install:
+    #!/usr/bin/env bash
+    set -euo pipefail
+    if [ -d "{{client_dir}}/node_modules" ]; then
+        echo "client/node_modules present — skipping install."
+    else
+        echo "Installing client dependencies (npm ci)…"
+        cd "{{client_dir}}" && npm ci
+    fi
+
+# Start the frontend against the local math3d-next backend.
+start: install
+    cd "{{client_dir}}" && \
+        PORT={{port}} \
+        REACT_APP_NEXT_API_CREATE_URL={{next_api}} \
+        REACT_APP_NEXT_API_RETRIEVE_URL={{next_api}} \
+        REACT_APP_DISABLE_LEGACY_SAVE=true \
+        npm start


### PR DESCRIPTION
### What are the relevant tickets?

N/A — dev tooling to support the ongoing migration to next.math3d.org.

### Description (What does it do?)

Adds a root `justfile` so local dev against a locally-running **math3d-next** backend is one command.

`just start`:
1. **`install`** (dependency) — runs `npm ci` in `client/` only if `client/node_modules` is missing; otherwise an instant no-op.
2. Runs the create-react-app dev server from `client/` with the env vars needed to talk to the local next backend:
   - `PORT=3141` — chosen to stay outside the 300–3010 range.
   - `REACT_APP_NEXT_API_CREATE_URL` / `REACT_APP_NEXT_API_RETRIEVE_URL` → `http://api.math3d.localdev:8000/v1/legacy_scenes/`, which drives `getGraph`/`saveGraph` in `client/src/services/api/index.js` to `POST .../v1/legacy_scenes/` and `GET .../v1/legacy_scenes/{key}`.
   - `REACT_APP_DISABLE_LEGACY_SAVE=true` — skips the dual-write to the dead legacy Node server (`/api/graph`, proxied to :5000) that `newSave` otherwise attempts.

The backend base is a `just` variable (`next_api`), so it's overridable, e.g. `just --set next_api https://api.math3d.org/v1/legacy_scenes/ start`.

### How can this be tested?

- Have `api.math3d.localdev` resolve to your local math3d-next backend (e.g. `/etc/hosts` → 127.0.0.1) and the backend running on :8000.
- Run `just start` from the repo root; confirm the app comes up on http://localhost:3141 and that saving/loading a scene round-trips through the local `v1/legacy_scenes/` endpoints.

### Additional Context

- **Backend note:** running the frontend at `http://localhost:3141` against `http://api.math3d.localdev:8000` is cross-origin, and the JSON POST triggers a preflight, so the next backend needs `http://localhost:3141` in `CORS_ALLOWED_ORIGINS`. CSRF should need no change since the frontend sends no credentials (plain `fetch`), as long as the legacy_scenes endpoint isn't relying on `SessionAuthentication`.
- Uses `npm ci` guarded on a missing `node_modules` rather than running unconditionally, so the common case (deps already installed) is instant.