### PR TITLE
Dual-publish releases to Cloudflare Workers alongside S3

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -5,18 +5,12 @@ concurrency: production
 on: workflow_dispatch
 
 jobs:
-  deployment:
+  build:
     runs-on: ubuntu-latest
     defaults:
       run:
         working-directory: client
     environment: production
-    env:
-      AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
-      AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
-      AWS_DEFAULT_REGION: ${{ vars.AWS_DEFAULT_REGION }}
-      AWS_S3_BUCKET: ${{ vars.AWS_S3_BUCKET }}
-      SKIP_YARN_COREPACK_CHECK: true
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v4
@@ -28,5 +22,55 @@ jobs:
           REACT_APP_NEXT_API_CREATE_URL: ${{ vars.REACT_APP_NEXT_API_CREATE_URL }}
           REACT_APP_NEXT_API_RETRIEVE_URL: ${{ vars.REACT_APP_NEXT_API_RETRIEVE_URL }}
           REACT_APP_DISABLE_LEGACY_SAVE: ${{ vars.REACT_APP_DISABLE_LEGACY_SAVE }}
+      - uses: actions/upload-artifact@v4
+        with:
+          name: client-build
+          path: client/build/
+          retention-days: 1
+
+  deploy-s3:
+    needs: build
+    runs-on: ubuntu-latest
+    environment: production
+    env:
+      AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
+      AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+      AWS_DEFAULT_REGION: ${{ vars.AWS_DEFAULT_REGION }}
+    steps:
+      - uses: actions/download-artifact@v4
+        with:
+          name: client-build
+          path: build/
       - run: aws s3 cp --recursive build s3://${{ vars.AWS_S3_BUCKET }}/
-      - run: aws cloudfront create-invalidation --distribution-id ${{vars.CLOUDFRONT_DISTRIBUTION_ID}} --paths "/*"
+      - run: aws cloudfront create-invalidation --distribution-id ${{ vars.CLOUDFRONT_DISTRIBUTION_ID }} --paths "/*"
+
+  # Dual-publish: deploy the same build artifact to Cloudflare Workers in
+  # parallel with the S3/CloudFront deploy above. Independent job so a
+  # Cloudflare failure never blocks the proven S3 path (and vice versa)
+  # during the bake period. Once Cloudflare is authoritative, delete the
+  # deploy-s3 job. See math3d-next#1176.
+  deploy-cloudflare:
+    needs: build
+    runs-on: ubuntu-latest
+    environment: production
+    # S3/CloudFront is the authoritative live origin during the dual-publish
+    # bake. A Cloudflare deploy failure should surface as a red check on THIS
+    # job but must not fail the overall release.
+    continue-on-error: true
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: "22"
+      - uses: actions/download-artifact@v4
+        with:
+          name: client-build
+          path: client/build/
+      - name: Deploy to Cloudflare Workers
+        working-directory: client
+        # wrangler is not a dependency of this legacy package (its Node 16
+        # toolchain predates it); run a pinned version via npx instead.
+        run: npx wrangler@4.107.0 deploy
+        env:
+          CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+          CLOUDFLARE_ACCOUNT_ID: ${{ vars.CLOUDFLARE_ACCOUNT_ID }}

--- a/.gitignore
+++ b/.gitignore
@@ -23,3 +23,6 @@ client/build
 npm-debug.log*
 yarn-debug.log*
 yarn-error.log*
+
+# wrangler local state
+.wrangler/

--- a/client/wrangler.jsonc
+++ b/client/wrangler.jsonc
@@ -1,0 +1,12 @@
+// Cloudflare Workers config for the legacy math3d-react site.
+// Serves the CRA production build (client/build) via Workers Static Assets.
+// Deployed by .github/workflows/release.yml (wrangler is not a local dependency;
+// CI runs it via npx). See https://github.com/ChristopherChudzicki/math3d-next/issues/1176.
+{
+  "name": "math3d-react",
+  "compatibility_date": "2026-07-04",
+  "assets": {
+    "directory": "./build",
+    "not_found_handling": "single-page-application"
+  }
+}


### PR DESCRIPTION
### What are the relevant tickets?

- https://github.com/ChristopherChudzicki/math3d-next/issues/1176

### Description (What does it do?)

Adds a Cloudflare Workers deploy to the Deploy workflow, running in parallel with the existing S3/CloudFront deploy (Phase A of the hosting migration plan in the issue above). The workflow is restructured to mirror math3d-next's `deploy-reusable.yml` pattern:

- **`build`** — builds the client (Node 16, same `REACT_APP_*` vars as before) and uploads `client/build` as an artifact, so both deploy targets ship byte-identical bits.
- **`deploy-s3`** — the existing S3 copy + CloudFront invalidation, unchanged in substance. Still the authoritative live origin.
- **`deploy-cloudflare`** — deploys the same artifact as a `math3d-react` Worker via `npx wrangler@4.107.0 deploy` (the version math3d-next pins) on Node 22. `continue-on-error: true`, so a Cloudflare failure surfaces as a red check on that job without failing the release.

New `client/wrangler.jsonc` configures the Worker: serves `./build` via Workers Static Assets with `single-page-application` not-found handling, matching math3d-next's config. Once Cloudflare is authoritative, dropping S3 is just deleting the `deploy-s3` job.

### How can this be tested?

Config was validated locally with `wrangler deploy --dry-run` (wrangler 4.107.0, Node 22) — it reads `client/wrangler.jsonc` and picks up assets from `client/build`.

End-to-end: after merging, run the Deploy workflow (`workflow_dispatch`). The S3 path should behave exactly as before; the Cloudflare job should publish the Worker, verifiable at `math3d-react.<account>.workers.dev` before any DNS changes.

**Pre-merge setup**: the `production` environment needs the `CLOUDFLARE_API_TOKEN` secret and `CLOUDFLARE_ACCOUNT_ID` variable (same values math3d-next uses). Until then the Cloudflare job fails harmlessly.

### Additional Context

- `wrangler` is intentionally **not** added to `client/package.json` — the legacy Node 16 toolchain predates it, so CI runs a pinned version via `npx` on Node 22 instead.
- Dropped `SKIP_YARN_COREPACK_CHECK` from the workflow env: it was copied from math3d-next's yarn-based workflow when this file was created (#387), and nothing in this npm-only repo reads it.
- Added `.wrangler/` to `.gitignore` for local wrangler state.

🤖 Generated with [Claude Code](https://claude.com/claude-code)