### PR TITLE
Fail the release when the Cloudflare deploy fails

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -45,18 +45,13 @@ jobs:
       - run: aws cloudfront create-invalidation --distribution-id ${{ vars.CLOUDFRONT_DISTRIBUTION_ID }} --paths "/*"
 
   # Dual-publish: deploy the same build artifact to Cloudflare Workers in
-  # parallel with the S3/CloudFront deploy above. Independent job so a
-  # Cloudflare failure never blocks the proven S3 path (and vice versa)
-  # during the bake period. Once Cloudflare is authoritative, delete the
-  # deploy-s3 job. See math3d-next#1176.
+  # parallel with the S3/CloudFront deploy above. Cloudflare serves the live
+  # custom domains, so a failed Cloudflare deploy fails the release. Once the
+  # dual-publish bake ends, delete the deploy-s3 job. See math3d-next#1176.
   deploy-cloudflare:
     needs: build
     runs-on: ubuntu-latest
     environment: production
-    # S3/CloudFront is the authoritative live origin during the dual-publish
-    # bake. A Cloudflare deploy failure should surface as a red check on THIS
-    # job but must not fail the overall release.
-    continue-on-error: true
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v4


### PR DESCRIPTION
### What are the relevant tickets?

- https://github.com/ChristopherChudzicki/math3d-next/issues/1176

### Description (What does it do?)

Removes `continue-on-error: true` from the `deploy-cloudflare` job. It was appropriate while S3/CloudFront was the authoritative origin and Cloudflare was a shadow deploy; now that the Cloudflare Workers serve live custom domains (`old.math3d.org` today, `www.math3d.org` at cutover), a failed Cloudflare deploy means users get a stale site — the release run should go red.

The `deploy-s3` job is intentionally left in place; deleting it is the final step once the dual-publish bake ends.

### How can this be tested?

Run the Deploy workflow. Behavior is identical when both deploys succeed; if the Cloudflare deploy fails, the workflow run now fails instead of showing green with a quietly red job.

🤖 Generated with [Claude Code](https://claude.com/claude-code)